### PR TITLE
Add Permanent emit parameters to signals.

### DIFF
--- a/signal.lua
+++ b/signal.lua
@@ -33,28 +33,32 @@ Registry.__index = function(self, key)
 	end)()
 end
 
-function Registry:register(s, f)
-	self[s][f] = f
+function Registry:register(s, f, ...)
+ 	self[s][f] = {f, {...}}
 	return f
 end
 
 function Registry:emit(s, ...)
-	for f in pairs(self[s]) do
-		f(...)
+	for i, f in pairs(self[s]) do
+        if # (f[2]) > 0 then
+            f[1](unpack(f[2]), ...)
+        else
+            f[1](...)
+        end
 	end
 end
 
 function Registry:remove(s, ...)
 	local f = {...}
 	for i = 1,select('#', ...) do
-		self[s][f[i]] = nil
+		self[s][f[i][1]] = nil
 	end
 end
 
 function Registry:clear(...)
 	local s = {...}
 	for i = 1,select('#', ...) do
-		self[s[i]] = {}
+		self[s[i][1]] = {}
 	end
 end
 


### PR DESCRIPTION
Extend the Hump signal's code to allow setting of variables to be emmitted
as methods are registered. This allows us (amongst other, general uses) to
use class methods as callbacks like so:

local foo = {
    name = 'bob'
}
function foo:saySomething(greeting)
    print(greeting .. self.name)
end

Signals.register('greeting', foo.saySomething, foo)

Signals.emit('greeting', 'Hello ')

Which will print 'Hello bob' correctly.
