### PR TITLE
Fix "self" param to the GS.leave callback

### DIFF
--- a/gamestate.lua
+++ b/gamestate.lua
@@ -36,7 +36,7 @@ function GS.new(t) return t or {} end -- constructor - deprecated!
 function GS.switch(to, ...)
 	assert(to, "Missing argument: Gamestate to switch to")
 	local pre = current
-	;(current.leave or __NULL__)(self)
+	;(current.leave or __NULL__)(current)
 	;(to.init or __NULL__)(to)
 	to.init = nil
 	current = to


### PR DESCRIPTION
Otherwise, switching out of the following state will give a nil error:

```
MyState = {
  count = 1
}

function MyState:leave()
  self.count = self.count + 1
end
```
