### PR TITLE
Update to gamestate to call leave outside of the loop switch was called

### DIFF
--- a/gamestate.lua
+++ b/gamestate.lua
@@ -70,7 +70,7 @@ end
 
 -- forward any undefined functions
 setmetatable(GS, {__index = function(_, func)
-	if func == 'update' and nextstate then
+	if nextstate then
 	  (current.leave or __NULL__)(current)
 	  current = nextstate
 	  nextstate = nil


### PR DESCRIPTION
See issue #15--This solves a problem I was having with cleanup by waiting until the next state function is called before calling leave.

It also handles the case where you call Gamestate.switch multiple times in the same loop by cleaning up the middle gamestate immediately.

The only problem I see with this is that it changes the order in which the functions are called--init and enter are called immediately so that enter can return the value, and leave is called after. This isn't a huge problem, as far as I can tell.
