### PR TITLE
Vector duck typing

### DIFF
--- a/vector.lua
+++ b/vector.lua
@@ -36,7 +36,7 @@ end
 local zero = new(0,0)
 
 local function isvector(v)
-	return (v.x ~= nil) and (v.y ~= nil)
+	return (v ~= nil) and (v.x ~= nil) and (v.y ~= nil)
 end
 
 function vector:clone()


### PR DESCRIPTION
If you import hump/vector in multiple places, 'vector' will be instantiated multiple times.  The current 'isvector' code only works on vectors created by the same import.  This pull fixes this issue by simply checking that 'x' and 'y' exist on the given object.
