### PR TITLE
add assertions to catch incorrect colon-calls to gamestate

### DIFF
--- a/gamestate.lua
+++ b/gamestate.lua
@@ -36,7 +36,7 @@ function GS.new(t) return t or {} end -- constructor - deprecated!
 
 function GS.switch(to, ...)
 	assert(to, "Missing argument: Gamestate to switch to")
-    assert( to ~= GS, "Can't call switch with colon operator" )
+	assert(to ~= GS, "Can't call switch with colon operator")
 	local pre = stack[#stack]
 	;(pre.leave or __NULL__)(pre)
 	;(to.init or __NULL__)(to)
@@ -47,7 +47,7 @@ end
 
 function GS.push(to, ...)
 	assert(to, "Missing argument: Gamestate to switch to")
-    assert( to ~= GS, "Can't call push with colon operator" )
+	assert(to ~= GS, "Can't call push with colon operator")
 	local pre = stack[#stack]
 	;(to.init or __NULL__)(to)
 	to.init = nil


### PR DESCRIPTION
If you accidentally call gamestate:switch() instead of gamestate.switch(), your game hangs before getting to the new state. Specifically, it tries using GS as the 'to' state and calls GS:enter, which the __index metamethod tries to find, which passes GS in, and so on, leading to infinite recursion.

This commit adds 2 simple assertions to tell the coder when they've made this hard-to-spot mistake. Because GS.switch and GS.push are not called frequently in normal usage, the extra checks shouldn't adversely affect performance. 

An alternative solution would be to detect and limit the recursion somehow, but that wouldn't be as helpful to the programmer as these asserts.
