### PR TITLE
Fixed error in reference to vector:rotated().

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@ end
 </div></div><div class="ref-block" id="hump.vectorvector:rotate_inplace"><h4>function <span class="name">vector:rotate_inplace</span><span class="arglist">(angle)</span><a class="top" href="#hump.vector">^top</a></h4><p>Rotate a vector in-place. Great to use on intermediate results.</p>
 
 <p><strong>This modifies the vector. If in doubt, use
-<a href="#hump.vectorrotate"><code class="lua">vector:rotate()</code></a>.</strong></p>
+<a href="#hump.vectorvector:rotated"><code class="lua">vector:rotated()</code></a>.</strong></p>
 <div class="arguments">Parameters:<dl>
 <dt>number <code class="lua">angle</code></dt>
 <dd>Rotation angle in radians.</dd></dl>


### PR DESCRIPTION
Link now also refers to the correct section, also fixed the spelling error.
