### PR TITLE
Fixes wrong arg #1 for resume().

### DIFF
--- a/gamestate.lua
+++ b/gamestate.lua
@@ -57,10 +57,10 @@ end
 
 function GS.pop(...)
 	assert(#stack > 1, "No more states to pop!")
-	local pre = stack[#stack]
+	local pre, to = stack[#stack], stack[#stack-1] 
 	stack[#stack] = nil
 	;(pre.leave or __NULL__)(pre)
-	return (stack[#stack].resume or __NULL__)(pre, ...)
+	return (to.resume or __NULL__)(to, ...)
 end
 
 function GS.current()


### PR DESCRIPTION
I find in my code

``` Lua
local State = {}
function State:resume()
    assert(self == State) -- Failed here when calling Gamestate.pop()
end
```

And this is a bug in Gamestate.pop(), and I fixed it, hope that will be useful.
