### PR TITLE
Timer Bug Fix - Fixed indeterminate behavior of new timers.

### DIFF
--- a/timer.lua
+++ b/timer.lua
@@ -32,7 +32,14 @@ local function _nothing_() end
 function Timer:update(dt)
 	local to_remove = {}
 
+	local handles = {}
+	local len = 0
 	for handle in pairs(self.functions) do
+		len = len + 1
+		handles[len] = handle
+	end
+
+	for _, handle in ipairs(handles) do
 		-- handle: {
 		--   time = <number>,
 		--   after = <function>,


### PR DESCRIPTION
Fixed bug where behavior of new timers added during iteration through timer handles was indeterminate.

On master, consider that while iterating through `self.functions`, we use `pairs`.

```lua
  -- timer.lua on master

  for handle in pairs(self.functions) do
    -- <update handle...>
  end
```

So, if we have a timer that does something like this:

```lua
local timerOne = Timer.after(1, function()
  local timerTwo = Timer.after(1, function() print('does something else') end)
end
```

Now, if we run `Timer.update(1), there are two possibilities.

A. timerTwo is updated later.

1. timerOne will finish.
2. timerOne will execute and create timerTwo, it will be added to somewhere considered "before" timerOne in `pairs(self.functions)`.
3. timerTwo **will not** be updated in this call of `Timer.update`.

B. timerTwo is updated immediately.

1. timerOne will finish.
2. timerOne will execute and create timerTwo, it will be added to somewhere considered "after" timerOne in `pairs(self.functions)`.
3. timerTwo **will** be updated in this call of `Timer.update`, thus printing "does something else" immediately.

To fix this issue, before starting to iterate through `self.functions`, we gather together all of the timer handles which currently exist, so that new timers will not be updated until the next call of `Timer.update()`.