### PR TITLE
Add floor division to hump.vector and hump.vector-light

### DIFF
--- a/vector-light.lua
+++ b/vector-light.lua
@@ -38,6 +38,10 @@ local function div(s, x,y)
 	return x/s, y/s
 end
 
+local function idiv(s, x,y)
+	return x//s, y//s
+end
+
 local function add(x1,y1, x2,y2)
 	return x1+x2, y1+y2
 end

--- a/vector.lua
+++ b/vector.lua
@@ -97,6 +97,11 @@ function vector.__div(a,b)
 	return new(a.x / b, a.y / b)
 end
 
+function vector.__idiv(a,b)
+	assert(isvector(a) and type(b) == "number", "wrong argument types (expected <vector> / <number>)")
+	return new(a.x // b, a.y // b)
+end
+
 function vector.__eq(a,b)
 	return a.x == b.x and a.y == b.y
 end


### PR DESCRIPTION
When defining operators on vectors, integer division `//` was left out, though it makes as much sense as the rest (and is specifically useful for games in the case of mapping onscreen coordinates to a grid).