### PR TITLE
changed the isvector() function in vector.lua

### DIFF
--- a/vector.lua
+++ b/vector.lua
@@ -52,7 +52,7 @@ local function randomDirection(len_min, len_max)
 end
 
 local function isvector(v)
-	return type(v) == 'table' and type(v.x) == 'number' and type(v.y) == 'number'
+	return getmetatable(v) == vector
 end
 
 function vector:clone()


### PR DESCRIPTION
I've changed the `isvector()` function inside vector.lua. Instead of checking that `v` is a table with number values of `x` and `y`, it checks if the meta table of `v` is `vector`, since any Vector object has `vector` as a meta table as defined in the `new` function. This way has a 100% accuracy of checking if it is a Vector object, whereas before any table with an x and y could have passed. 

I'm not sure if you have it this way on purpose, due to speed or some other factor; if so, just shoot me down.

Have a good day :)