### PR TITLE
added init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,16 @@
+local dir = (...) .. '.'
+assert(not dir:match('%.init%.$'), "Invalid require path `"..(...).."' (remove the `.init').")
+
+local function get(mod_name)
+	return require(dir..mod_name)
+end
+
+return {
+	camera       = get("camera"),
+	class        = get("class"),
+	gamestate    = get("gamestate"),
+	signal       = get("signal"),
+	timer        = get("timer"),
+	vector_light = get("vector-light"),
+	vector       = get("vector")
+}


### PR DESCRIPTION
Added init file to load all modules with one line of code :)
All hump modules can be loaded with `hump = require("hump")` instead of loading all modules one at a time.

To access the (for example) camera module, it is now stored in `hump.camera`. Normal way of loading each module on its own is still possible!